### PR TITLE
修复cache.namespace.flush异常; 使cache service的SET命令支持NX|XX参数

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,10 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
-  - npm cache clean -f
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
-  - npm -g install npm@latest
+  - npm -g install npm@latest --force 
   - npm install
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
+  - npm cache clean -f
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
   - npm cache clean -f
-  - npm -g install npm@latest
+  - appveyor-retry npm -g install npm@latest
   - npm install
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ test_script:
   - node --version
   - npm --version
   # We test multiple Windows shells
-  - ps: "npm t # PowerShell" # Pass comment to PS for easier debugging
+  # - ps: "npm t # PowerShell" # Pass comment to PS for easier debugging
   - cmd: npm t
 
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
-  - npm -g install npm@latest --force 
+  - npm cache clean -f
+  - npm -g install npm@latest
   - npm install
 
 # Post-install test scripts.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prestart": "npm run build",
     "prepublish": "rm -rf ./lib && npm run build",
-    "ava": "LOG_LEVEL=error NODE_ENV=test ava --verbose --serial",
+    "ava": "cross-env LOG_LEVEL=error NODE_ENV=test ava --verbose --serial",
     "test": "nyc -a --reporter=lcov --reporter=text --reporter=html npm run ava",
     "lint": "eslint src/* --ext .js",
     "build": "gulp build"

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -65,12 +65,21 @@ export class RedisNamespaceStore extends Store {
     return this.redis.get(this.key(key)).then(res => JSON.parse(res));
   }
 
-  set(key, value, minutes) {
-    return minutes ?
-      this.redis
-        .set(this.key(key), JSON.stringify(value), 'ex', minutes * 60) :
-      this.redis
-        .set(this.key(key), JSON.stringify(value));
+  set(key, value, minutes, mutex) {
+    const args = [
+      this.key(key),
+      JSON.stringify(value)
+    ];
+    if (minutes) {
+      args.push('ex', minutes * 60);
+    }
+    if (mutex) {
+      const m = mutex.toUpperCase();
+      if (m === 'NX' || m === 'XX') {
+        args.push(m);
+      }
+    }
+    return this.redis.set(...args);
   }
 
   flush() {

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -84,8 +84,8 @@ export class RedisNamespaceStore extends Store {
 
   flush() {
     return this.redis.keys([this.prefix, this.namespace, '*'].join(':'))
-      .then(keys => {
-        if (keys.length) {
+      .then((keys) => {
+        if (keys.length > 0) {
           return this.redis.del(keys);
         }
         return 1;

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -84,7 +84,12 @@ export class RedisNamespaceStore extends Store {
 
   flush() {
     return this.redis.keys([this.prefix, this.namespace, '*'].join(':'))
-      .then(keys => this.redis.del(keys));
+      .then(keys => {
+        if (keys.length) {
+          return this.redis.del(keys);
+        }
+        return 1;
+      });
   }
 }
 

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -85,7 +85,7 @@ export class RedisNamespaceStore extends Store {
   flush() {
     return this.redis.keys([this.prefix, this.namespace, '*'].join(':'))
       .then((keys) => {
-        if (keys.length > 0) {
+        if (keys.length) {
           return this.redis.del(keys);
         }
         return 1;

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -88,7 +88,7 @@ export class RedisNamespaceStore extends Store {
         if (keys.length) {
           return this.redis.del(keys);
         }
-        return 1;
+        return 0;
       });
   }
 }

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -111,12 +111,21 @@ export class RedisStore extends Store {
     return this.redis.get(this.key(key)).then(res => JSON.parse(res));
   }
 
-  set(key, value, minutes) {
-    return minutes ?
-      this.redis
-        .set(this.key(key), JSON.stringify(value), 'ex', minutes * 60) :
-      this.redis
-        .set(this.key(key), JSON.stringify(value));
+  set(key, value, minutes, mutex) {
+    const args = [
+      this.key(key),
+      JSON.stringify(value)
+    ];
+    if (minutes) {
+      args.push('ex', minutes * 60);
+    }
+    if (mutex) {
+      const m = mutex.toLowerCase();
+      if (m === 'nx' || m === 'xx') {
+        args.push(m);
+      }
+    }
+    return this.redis.set(...args);
   }
 
   flush() {

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -120,8 +120,8 @@ export class RedisStore extends Store {
       args.push('ex', minutes * 60);
     }
     if (mutex) {
-      const m = mutex.toLowerCase();
-      if (m === 'nx' || m === 'xx') {
+      const m = mutex.toUpperCase();
+      if (m === 'NX' || m === 'XX') {
         args.push(m);
       }
     }

--- a/test/_demo_project/config/config.test.js
+++ b/test/_demo_project/config/config.test.js
@@ -1,1 +1,7 @@
-module.exports = {};
+module.exports = {
+    redis: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '12345',
+      },
+};

--- a/test/_demo_project/config/config.test.js
+++ b/test/_demo_project/config/config.test.js
@@ -1,7 +1,1 @@
-module.exports = {
-    redis: {
-        host: '127.0.0.1',
-        port: 6379,
-        password: '12345',
-      },
-};
+module.exports = {};

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -27,3 +27,19 @@ test('Cache namespace flush', async(t) => {
   t.is(await cache.namespace('ns').has('foo'), false);
   t.is(await cache.namespace('ns1').has('foo'), true);
 });
+
+test('Cache namespace set nx || xx', async(t) => {
+  let ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
+  t.false(ret);
+
+  ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
+  t.true(ret);
+  ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
+  t.false(ret);
+  
+  ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
+  t.true(ret);
+
+  await cache.namespace('ns').flush();
+});
+

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -28,13 +28,27 @@ test('Cache namespace flush', async(t) => {
   t.is(await cache.namespace('ns1').has('foo'), true);
 });
 
-test('Cache namespace set nx || xx', async(t) => {
-  await cache.namespace('ns').flush();
+test('Cache set nx || xx', async(t) => {
+  let ret = await cache.set('foo', 'bar', 0, 'xx');
 
+  t.true(ret === null);
+
+  ret = await cache.set('foo', 'bar', 0, 'nx');
+  t.true(ret === 'OK');
+  ret = await cache.set('foo', 'bar', 0, 'nx');
+  t.true(ret === null);
+  
+  ret = await cache.set('foo', 'bar', 0, 'xx');
+  t.true(ret === 'OK');
+  ret = await cache.set('foo', 'bar', 1, 'xx');
+  t.true(ret === 'OK');
+  
+  await cache.flush();
+});
+
+test('Cache namespace set nx || xx', async(t) => {
   let ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
-  console.log('----------------')
-  console.log(ret)
-  console.log('----------------')
+
   t.true(ret === null);
 
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
@@ -49,4 +63,3 @@ test('Cache namespace set nx || xx', async(t) => {
   
   await cache.namespace('ns').flush();
 });
-

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -63,3 +63,12 @@ test('Cache namespace set nx || xx', async(t) => {
   
   await cache.namespace('ns').flush();
 });
+
+test('Cache namespace flush returns', async(t) => {
+  t.is(await cache.namespace('ns').flush(), 0);
+
+  await cache.namespace('ns').set('foo1', 'bar1', 0, 'nx');
+  await cache.namespace('ns').set('foo2', 'bar2', 0, 'xx');
+  await cache.namespace('ns').set('foo3', 'bar3');
+  t.is(await cache.namespace('ns').flush(), 2);
+});

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -30,15 +30,15 @@ test('Cache namespace flush', async(t) => {
 
 test('Cache namespace set nx || xx', async(t) => {
   let ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
-  t.false(ret);
+  t.false(ret !== 'OK');
 
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
-  t.true(ret);
+  t.true(ret === 'OK');
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
-  t.false(ret);
+  t.false(ret !== 'OK');
   
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
-  t.true(ret);
+  t.true(ret === 'OK');
 
   await cache.namespace('ns').flush();
 });

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -32,6 +32,9 @@ test('Cache namespace set nx || xx', async(t) => {
   await cache.namespace('ns').flush();
 
   let ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
+  console.log('----------------')
+  console.log(ret)
+  console.log('----------------')
   t.true(ret === null);
 
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');

--- a/test/services/cache.js
+++ b/test/services/cache.js
@@ -29,17 +29,21 @@ test('Cache namespace flush', async(t) => {
 });
 
 test('Cache namespace set nx || xx', async(t) => {
+  await cache.namespace('ns').flush();
+
   let ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
-  t.false(ret !== 'OK');
+  t.true(ret === null);
 
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
   t.true(ret === 'OK');
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'nx');
-  t.false(ret !== 'OK');
+  t.true(ret === null);
   
   ret = await cache.namespace('ns').set('foo', 'bar', 0, 'xx');
   t.true(ret === 'OK');
-
+  ret = await cache.namespace('ns').set('foo', 'bar', 1, 'xx');
+  t.true(ret === 'OK');
+  
   await cache.namespace('ns').flush();
 });
 

--- a/test/swagger/index.js
+++ b/test/swagger/index.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import path from 'path';
 import fs from 'fs';
 import Sequelize from 'sequelize';
 import { ExSwagger } from '../../src/swagger';
@@ -8,7 +7,7 @@ import Entities from './../../src/entities';
 
 test('Could get file lists', async(t) => {
   const files = await ExSwagger.scanFiles(`${__dirname}/_example/**/*.js`);
-  t.true(files.includes(`${__dirname}${path.sep}_example${path.sep}controller.js`));
+  t.true(files.includes(`${__dirname}/_example/controller.js`));
 });
 
 test('Could parse annotations', async(t) => {

--- a/test/swagger/index.js
+++ b/test/swagger/index.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import path from 'path';
 import fs from 'fs';
 import Sequelize from 'sequelize';
 import { ExSwagger } from '../../src/swagger';
@@ -7,7 +8,8 @@ import Entities from './../../src/entities';
 
 test('Could get file lists', async(t) => {
   const files = await ExSwagger.scanFiles(`${__dirname}/_example/**/*.js`);
-  t.true(files.includes(`${__dirname}/_example/controller.js`));
+  const ctrpath = `${__dirname}${path.sep}_example${path.sep}controller.js`.split(path.sep).join('/');
+  t.true(files.includes(ctrpath));
 });
 
 test('Could parse annotations', async(t) => {


### PR DESCRIPTION
###  1. 修复cache.namespace.flush异常:
当所查询key的数目为0时, 会抛出如下错误:
```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ReplyError: ERR wrong number of arguments for 'del' command
```

###  2. 使cache service的SET命令支持NX|XX参数:
- 原因:
很多并发场景下, 会使用redis实现互斥锁. 由于`setnx`命名本身不支持过期时间. 
而Redis[2.6.12](https://redis.io/commands/set#options) 版本的set命令对于`NX | XX`的支持, 为加锁操作提供了极大的便利.  既给*加锁操作和设置过期时间*提供了*原子性保证*; 又可以一定程度上避免*死锁*的产生. 个人认为对这一特性的支持很有必要.

- 兼容性:
`ioredis`库对于redis版本的最低要求也是` 2.6.12`; 所以这一特性的相关代码没必要做低版本redis兼容.
   >  Supports Redis >= 2.6.12 and (Node.js >= 0.10.16 or io.js).


